### PR TITLE
Remove text & link to Issue 1 which is now closed

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -93,10 +93,6 @@ x$delete("foo.txt")
 x$list()
 ```
 
-## todo
-
-see [issue 1](https://github.com/ropensci/hoardr/issues/1)
-
 ## Meta
 
 * Please [report any issues or bugs](https://github.com/ropensci/hoardr/issues).


### PR DESCRIPTION
As it says on the tin, removes a link to the Todo that is now closed.

## Description
Deletes redundant text.

## Related Issue
#1

## Example
Just text in the README, no changes to the codebase