### PR TITLE
Fix tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,3 +29,4 @@ RoxygenNote: 7.2.3
 X-schema.org-applicationCategory: Data
 X-schema.org-keywords: caching, data, files, xml, pdf
 X-schema.org-isPartOf: https://ropensci.org
+Config/testthat/edition: 3

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,2 +1,3 @@
 library("testthat")
+library("hoardr")
 test_check("hoardr")

--- a/tests/testthat/test-HoardClient.R
+++ b/tests/testthat/test-HoardClient.R
@@ -1,13 +1,11 @@
-context("HoardClient - when files don't exist")
-
-test_that("HoardClient works", {
+test_that("HoardClient works when files don't exist", {
   aa <- HoardClient
-  expect_is(aa, "R6ClassGenerator")
+  expect_s3_class(aa, "R6ClassGenerator")
 
   bb <- HoardClient$new()
 
-  expect_is(bb, "HoardClient")
-  expect_is(bb, "R6")
+  expect_s3_class(bb, "HoardClient")
+  expect_s3_class(bb, "R6")
   expect_null(bb$path)
   expect_null(bb$type)
 
@@ -17,13 +15,13 @@ test_that("HoardClient works", {
 
   # test cache_path_get method
   ## before set
-  expect_is(bb$cache_path_get, "function")
+  expect_equal(class(bb$cache_path_get), "function")
   expect_null(bb$cache_path_get())
 
   # test cache_path_set method
-  expect_is(bb$cache_path_set, "function")
+  expect_equal(class(bb$cache_path_set), "function")
   expect_equal(length(bb$cache_path_set()), 0)
-  expect_is(
+  expect_type(
     bb$cache_path_set(path = "test123", type = 'tempdir'),
     "character"
   )
@@ -33,7 +31,7 @@ test_that("HoardClient works", {
   )
 
   # use full_path
-  expect_is(
+  expect_type(
     bb$cache_path_set(full_path = tempdir()),
     'character'
   )
@@ -45,59 +43,59 @@ test_that("HoardClient works", {
 
   # test cache_path_get method
   ## after set
-  expect_is(bb$cache_path_get(), "character")
+  expect_type(bb$cache_path_get(), "character")
 
   # test list method
-  expect_is(bb$list, "function")
+  expect_equal(class(bb$list), "function")
   expect_equal(length(bb$list()), 0)
 
   # test mkdir method
-  expect_is(bb$mkdir, "function")
+  expect_equal(class(bb$mkdir), "function")
   expect_false(dir.exists(bb$cache_path_get()))
   expect_true(bb$mkdir())
   expect_true(dir.exists(bb$cache_path_get()))
 
   # test delete method
-  expect_is(bb$delete, "function")
+  expect_equal(class(bb$delete), "function")
   ## no files input
   expect_error(bb$delete(), "argument \"files\" is missing")
 
   # test delete_all method
-  expect_is(bb$delete_all, "function")
+  expect_equal(class(bb$delete_all), "function")
   ## no files input
   expect_message(bb$delete_all(), "no files found")
   expect_null(suppressMessages(bb$delete_all()))
 
   # test details method
-  expect_is(bb$details, "function")
+  expect_equal(class(bb$details), "function")
   ## no files in yet
   deets1 <- bb$details()
   expect_equal(length(deets1), 0)
 
   # test key method
-  expect_is(bb$key, "function")
+  expect_equal(class(bb$key), "function")
   ## no x param passed
   expect_error(bb$key(), "argument \"x\" is missing")
   ## no files in yet
   expect_error(bb$key(x = "adfdf"), "file does not exist")
 
   # test keys method
-  expect_is(bb$keys, "function")
+  expect_equal(class(bb$keys), "function")
   ## no files in yet, gives NULL
   expect_null(bb$keys())
 
   # test files method
-  expect_is(bb$files, "function")
+  expect_equal(class(bb$files), "function")
   ## no files in yet, gives NULL
   expect_null(bb$files())
 
   # test compress method
-  expect_is(bb$compress, "function")
+  expect_equal(class(bb$compress), "function")
   ## no files in yet, gives error
   expect_error(bb$compress(), "no files to compress")
 
   # test uncompress method
-  expect_is(bb$uncompress, "function")
+  expect_equal(class(bb$uncompress), "function")
   ## no files in yet, gives error
   expect_message(bb$uncompress(), "no files to uncompress")
 
@@ -105,20 +103,18 @@ test_that("HoardClient works", {
   ## add some files first
   cat(1:10000L, file = file.path(bb$cache_path_get(), "bar1.txt"))
   cat(1:10000L, file = file.path(bb$cache_path_get(), "bar2.txt"))
-  expect_is(bb$exists('bar1.txt'), "data.frame")
+  expect_s3_class(bb$exists('bar1.txt'), "data.frame")
   expect_true(bb$exists('bar1.txt')$exists)
   expect_false(bb$exists('asdfasdsdf')$exists)
   ## no files in yet, gives error
   expect_error(bb$exists(), "argument \"files\" is missing")
 })
 
-context("HoardClient - when files exist")
-
-test_that("HoardClient works", {
+test_that("HoardClient works when files exist", {
   cc <- HoardClient$new()
 
-  expect_is(cc, "HoardClient")
-  expect_is(cc, "R6")
+  expect_s3_class(cc, "HoardClient")
+  expect_s3_class(cc, "R6")
 
   # set cache path
   cc$cache_path_set(path = "test456", type = 'tempdir')
@@ -133,9 +129,9 @@ test_that("HoardClient works", {
   cat(1:10000L, file = file.path(cc$cache_path_get(), "foo3.txt"))
 
   # test list method
-  expect_is(cc$list, "function")
+  expect_equal(class(cc$list), "function")
   expect_equal(length(cc$list()), 4)
-  expect_is(cc$list(), "character")
+  expect_type(cc$list(), "character")
 
   # test delete method
   expect_error(cc$delete(), "argument \"files\" is missing")
@@ -151,9 +147,9 @@ test_that("HoardClient works", {
 
   # test details method
   deets1 <- cc$details()
-  expect_is(deets1, "cache_info")
+  expect_equal(class(deets1), "cache_info")
   expect_equal(length(deets1), 4)
-  expect_is(deets1[[1]], "list")
+  expect_type(deets1[[1]], "list")
   expect_named(deets1[[1]], c('file', 'type', 'size'))
   ## print method print.cache_info
   expect_output(print(deets1), "<cached files>")
@@ -162,22 +158,22 @@ test_that("HoardClient works", {
   expect_output(print(deets1), "mb")
 
   # test key method
-  expect_is(cc$key(x = cc$list()[1]), "character")
+  expect_type(cc$key(x = cc$list()[1]), "character")
   expect_identical(cc$key(x = cc$list()[1]), cc$key(x = cc$list()[1]))
 
   # test keys method
-  expect_is(cc$keys(), "character")
+  expect_type(cc$keys(), "character")
   expect_equal(length(cc$keys()), 4)
 
   # test files method
-  expect_is(cc$files(), "list")
+  expect_type(cc$files(), "list")
   zz <- cc$files()[[1]]
-  expect_is(zz, "HoardFile")
-  expect_is(zz$exists, "function")
+  expect_s3_class(zz, "HoardFile")
+  expect_equal(class(zz$exists), "function")
   expect_true(zz$exists())
-  expect_is(zz$path, "character")
+  expect_type(zz$path, "character")
   expect_equal(zz$path, cc$list()[1])
-  expect_is(zz$print, "function")
+  expect_equal(class(zz$print), "function")
   expect_output(zz$print(), "<hoard file>")
   expect_output(zz$print(), "path:")
 

--- a/tests/testthat/test-HoardClient.R
+++ b/tests/testthat/test-HoardClient.R
@@ -32,7 +32,7 @@ test_that("HoardClient works when files don't exist", {
 
   # use full_path
   expect_type(
-    bb$cache_path_set(full_path = tempdir()),
+    bb$cache_path_set(full_path = file.path(tempdir(), "foobar")),
     'character'
   )
 

--- a/tests/testthat/test-hoard.R
+++ b/tests/testthat/test-hoard.R
@@ -1,27 +1,25 @@
-context("hoard")
 test_that("hoard works", {
   aa <- hoard()
 
-  expect_is(aa, "HoardClient")
-  expect_is(aa, "R6")
-  expect_is(aa$cache_path_get, "function")
-  expect_is(aa$cache_path_set, "function")
-  expect_is(aa$compress, "function")
-  expect_is(aa$uncompress, "function")
-  expect_is(aa$delete, "function")
-  expect_is(aa$delete_all, "function")
-  expect_is(aa$details, "function")
-  expect_is(aa$files, "function")
-  expect_is(aa$key, "function")
-  expect_is(aa$keys, "function")
-  expect_is(aa$list, "function")
-  expect_is(aa$mkdir, "function")
+  expect_s3_class(aa, "HoardClient")
+  expect_s3_class(aa, "R6")
+  expect_equal(class(aa$cache_path_get), "function")
+  expect_equal(class(aa$cache_path_set), "function")
+  expect_equal(class(aa$compress), "function")
+  expect_equal(class(aa$uncompress), "function")
+  expect_equal(class(aa$delete), "function")
+  expect_equal(class(aa$delete_all), "function")
+  expect_equal(class(aa$details), "function")
+  expect_equal(class(aa$files), "function")
+  expect_equal(class(aa$key), "function")
+  expect_equal(class(aa$keys), "function")
+  expect_equal(class(aa$list), "function")
+  expect_equal(class(aa$mkdir), "function")
   expect_null(aa$path)
   expect_null(aa$type)
 })
 
-context("hoard: multiple instances")
-test_that("hoard works", {
+test_that("hoard works with multiple instances", {
   aa <- hoard()
   bb <- hoard()
 
@@ -36,7 +34,6 @@ test_that("hoard works", {
   expect_match(bb$cache_path_get(), 'helloworld')
 })
 
-context("hoard: fails well")
 test_that("hoard fails well", {
   expect_error(hoard(f = 5),
                  "unused argument")

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,18 +1,16 @@
-context("util functions")
-
 test_that("ct", {
-  expect_is(ct, "function")
+  expect_equal(class(ct), "function")
   expect_equal(length(ct(list(NULL, 4))), 1)
 })
 
 test_that("assert_is", {
-  expect_is(assert_is, "function")
+  expect_equal(class(assert_is), "function")
   expect_null(assert_is(TRUE, "logical"))
   expect_error(assert_is(TRUE, "character"), "TRUE must be of class character")
 })
 
 test_that("assert_n", {
-  expect_is(assert_n, "function")
+  expect_equal(class(assert_n), "function")
   expect_null(assert_n(letters, 26))
   expect_error(assert_n(letters, 4), "letters must be length 4")
 })


### PR DESCRIPTION
CRAN maintainers notified me about check errors:
https://cran.r-project.org/web/checks/check_results_hoardr.html

I'm not 100% sure what caused the issue, it seems `unlink()` did not delete the cache directory when I ran tests using `devtools::test()`.  Strange behaviour though, `dir.exists(cache_dir)` returned FALSE, but `file.exists(cache_dir)` returned TRUE. 

This PR updates cache dir full path in `test-HoardClient.R` line 35 from `tempdir()` to a subdirectory of `tempdir()` which fixes the issue. I also upgraded testthat to edition 3.

I'll merge this PR and issue a patch release to keep the package from being archived on CRAN.