### PR TITLE
Normalise slash directions in paths

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Suggests:
     testthat,
     knitr,
     rmarkdown
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 X-schema.org-applicationCategory: Data
 X-schema.org-keywords: caching, data, files, xml, pdf
 X-schema.org-isPartOf: https://ropensci.org

--- a/R/hoard-package.R
+++ b/R/hoard-package.R
@@ -16,4 +16,4 @@
 #' @docType package
 #' @author Scott Chamberlain \email{myrmecocystus@@gmail.com}
 #' @keywords package
-NULL
+"_PACKAGE"

--- a/R/hoard_client.R
+++ b/R/hoard_client.R
@@ -204,9 +204,9 @@ HoardClient <- R6::R6Class(
       if (is.null(full_path)) {
         self$path <- path
         private$hoard_env$cache_path <-
-          file.path(eval(parse(text = type))(), prefix, path)
+          chartr("\\", "/", file.path(eval(parse(text = type))(), prefix, path))
       } else {
-        private$hoard_env$cache_path <- full_path
+        private$hoard_env$cache_path <- chartr("\\", "/", full_path)
       }
       # return path to user
       self$cache_path_get()

--- a/R/hoard_client.R
+++ b/R/hoard_client.R
@@ -28,7 +28,7 @@
 #'       \itemize{
 #'        \item path (character) the path to be appended to the cache path set
 #'         by `type`
-#'        \item type (character) the type of cache, see [rappdirs]
+#'        \item type (character) the type of cache, see [rappdirs::rappdirs()].
 #'        \item prefix (character) prefix to the `path` value. Default: "R"
 #'        \item full_path (character) instead of using `path`, `type`, and `prefix`
 #'         just set the full path with this parameter

--- a/man/hoard.Rd
+++ b/man/hoard.Rd
@@ -35,7 +35,7 @@ actually make the directory, but just sets the path to it.
 \itemize{
 \item path (character) the path to be appended to the cache path set
 by \code{type}
-\item type (character) the type of cache, see \link{rappdirs}
+\item type (character) the type of cache, see \code{\link[rappdirs:rappdirs-package]{rappdirs::rappdirs()}}.
 \item prefix (character) prefix to the \code{path} value. Default: "R"
 \item full_path (character) instead of using \code{path}, \code{type}, and \code{prefix}
 just set the full path with this parameter

--- a/man/hoardr-package.Rd
+++ b/man/hoardr-package.Rd
@@ -15,6 +15,15 @@ files for another R package. In addition, you can export functions in
 your own package using \code{hoardr} for users to manage their cached
 files.
 }
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://docs.ropensci.org/hoardr/}
+  \item \url{https://github.com/ropensci/hoardr}
+  \item Report bugs at \url{https://github.com/ropensci/hoardr/issues}
+}
+
+}
 \author{
 Scott Chamberlain \email{myrmecocystus@gmail.com}
 }


### PR DESCRIPTION
Received the following from CRAN Team:
https://cran.r-project.org/web/checks/check_results_hoardr.html

I suspect the issue is around mixed slash types on MS Windows:
"D:\\temp\\2025_01_13_01_50_00_7580\\RtmpaE7w0C/foobar"

My understanding is that under MS Windows paths use "\\" and Unix based systems use "/". However, I read that R can interpret "/" on MS Windows as well. Therefore, with this PR I try to fix test errors by replacing all "\\" characters with "/".

Before opening this PR I ran `devtools::check_win_devel()`, the fix seems to work.